### PR TITLE
Update usbip-device to use Git source

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1374,9 +1374,9 @@ dependencies = [
 
 [[package]]
 name = "usb-device"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6be90410d4772074ea49525e2e753b65920b94b57eee21a6ef7b6a6fe6296245"
+checksum = "1f6cc3adc849b5292b4075fc0d5fdcf2f24866e88e336dd27a8943090a520508"
 
 [[package]]
 name = "usbd-ctaphid"
@@ -1396,9 +1396,9 @@ dependencies = [
 
 [[package]]
 name = "usbip-device"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7360c60ef8f529275589238b51de334ecf76aac0bffc2a2638414bc9da09731"
+checksum = "2e7a0b57d68d666cc85d8bfe8a32fb4196e8eb89b611658a0624af6428e7a2fd"
 dependencies = [
  "bitflags",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ interchange = "0.2.0"
 log = { version = "0.4.14", default-features = false }
 trussed = { version = "0.1", features = ["virt"] }
 usb-device = { version = "0.2.7", default-features = false }
-usbip-device = "0.1.4"
+usbip-device = "0.1.5"
 
 # ctaphid
 ctaphid-dispatch = { version = "0.1", optional = true }

--- a/README.md
+++ b/README.md
@@ -5,18 +5,11 @@ to the OS, and should allow faster development of the embedded applications.
 
 Remarks:
 - Extensible with CTAP apps: currently FIDO and Admin are active;
-- Works with Chromium and pynitrokey (with a patched fido2.hid module) [2];
-- Written length returns "1", which confuse client HID applications
-  (Chromium shows error in logs, but ignores it; pynitrokey fails);
 - Does not work with Firefox at the moment;
 - Allows to inject own FIDO certificates, and device properties;
 - Requires multiple `usbip attach` calls to make it work [1].
 
 [1] https://github.com/Sawchord/usbip-device#known-bugs
-
-[2] The change is rather simple: replace `raise OSError("failed to write entire packet")` with `pass` in `FileCtapHidConnection.write_packet` in fido2’s `hid/base.py`. The patch is provided at [3].
-
-[3] ./fido2-patch/0001-Ignore-difference-between-the-sent-data-size-and-rep.patch
 
 ## Setup
 


### PR DESCRIPTION
By using an unreleased usbip-device version, we can work around the
issue with wrong byte counts reported to the host system.

Fixes https://github.com/trussed-dev/pc-usbip-runner/issues/9