### PR TITLE
Introduce Apps trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1333,6 +1333,7 @@ dependencies = [
  "clap",
  "clap-num",
  "ctaphid-dispatch",
+ "delog",
  "fido-authenticator",
  "interchange",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1292,7 +1292,7 @@ checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 [[package]]
 name = "trussed"
 version = "0.1.0"
-source = "git+https://github.com/trussed-dev/trussed?rev=3da56d8#3da56d8e41b9de64b852ed2bdcfd623118b09c3d"
+source = "git+https://github.com/trussed-dev/trussed?rev=fdf96da#fdf96da43b0d09e59e34778d064650d362d24a3d"
 dependencies = [
  "aes",
  "bitflags",
@@ -1314,7 +1314,6 @@ dependencies = [
  "interchange",
  "littlefs2",
  "nb 1.0.0",
- "once_cell",
  "p256-cortex-m4",
  "postcard",
  "rand_core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -408,9 +408,9 @@ checksum = "b365fabc795046672053e29c954733ec3b05e4be654ab130fe8f1f94d7051f35"
 
 [[package]]
 name = "delog"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e371811fb858c17e75e0316e7ebf8db0343b10d73038a3b9571006b0e7e5cc53"
+checksum = "4cd67f90cc14e0a91cf693141453cccf2b74db9d59c40f6be18b79169fe77dfd"
 dependencies = [
  "log",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,4 +34,4 @@ name = "fido"
 required-features = ["ctaphid"]
 
 [patch.crates-io]
-trussed = { git = "https://github.com/trussed-dev/trussed", rev = "3da56d8" }
+trussed = { git = "https://github.com/trussed-dev/trussed", rev = "fdf96da" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ usbd-ctaphid = { git = "https://github.com/Nitrokey/nitrokey-3-firmware", option
 [dev-dependencies]
 clap = { version = "3.0.0", features = ["derive"] }
 clap-num = "1.0.0"
+delog = { version = "0.1.6", features = ["std-log"] }
 pretty_env_logger = "0.4.0"
 trussed = { version = "0.1", features = ["clients-3"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,13 +7,13 @@ edition = "2021"
 [dependencies]
 interchange = "0.2.0"
 log = { version = "0.4.14", default-features = false }
-trussed = { version = "0.1", features = ["virt"] }
+trussed = { version = "0.1", features = ["log-all", "virt"] }
 usb-device = { version = "0.2.7", default-features = false }
 usbip-device = "0.1.5"
 
 # ctaphid
-ctaphid-dispatch = { version = "0.1", optional = true }
-usbd-ctaphid = { git = "https://github.com/Nitrokey/nitrokey-3-firmware", optional = true }
+ctaphid-dispatch = { version = "0.1", features = ["log-all"], optional = true }
+usbd-ctaphid = { git = "https://github.com/Nitrokey/nitrokey-3-firmware", features = ["log-all"], optional = true }
 
 [dev-dependencies]
 clap = { version = "3.0.0", features = ["derive"] }

--- a/examples/fido.rs
+++ b/examples/fido.rs
@@ -129,7 +129,8 @@ fn main() {
     log::info!("Initializing Trussed");
     trussed_usbip::Runner::new(store, options)
         .init_platform(move |platform| {
-            let ui: Box<dyn trussed::platform::UserInterface> = Box::new(UserInterface::new());
+            let ui: Box<dyn trussed::platform::UserInterface + Send + Sync> =
+                Box::new(UserInterface::new());
             platform.user_interface().set_inner(ui);
 
             if let Some(fido_key) = &args.fido_key {

--- a/src/ctaphid.rs
+++ b/src/ctaphid.rs
@@ -1,9 +1,7 @@
-use ctaphid_dispatch::{app::App, dispatch::Dispatch, types::HidInterchange};
+use ctaphid_dispatch::{dispatch::Dispatch, types::HidInterchange};
 use interchange::Interchange as _;
 use usb_device::bus::{UsbBus, UsbBusAllocator};
 use usbd_ctaphid::CtapHid;
-
-use crate::Application;
 
 pub fn setup<B: UsbBus>(bus_allocator: &UsbBusAllocator<B>) -> (CtapHid<'_, B>, Dispatch) {
     let (ctaphid_rq, ctaphid_rp) = HidInterchange::claim().unwrap();
@@ -13,13 +11,4 @@ pub fn setup<B: UsbBus>(bus_allocator: &UsbBusAllocator<B>) -> (CtapHid<'_, B>, 
         .implements_wink();
     let ctaphid_dispatch = Dispatch::new(ctaphid_rp);
     (ctaphid, ctaphid_dispatch)
-}
-
-pub fn apps(all: &mut [Application]) -> Vec<&mut dyn App> {
-    let mut apps = Vec::new();
-    for app in all {
-        let Application::Ctaphid(app) = app;
-        apps.push(app.as_mut() as &mut dyn App);
-    }
-    apps
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,7 +109,7 @@ impl<S: StoreProvider + Clone> Runner<S> {
             let (mut ctaphid, mut ctaphid_dispatch) = ctaphid::setup(&bus_allocator);
 
             let mut usb_device = build_device(&bus_allocator, &self.options);
-            let mut service = Rc::new(RefCell::new(Service::new(platform)));
+            let mut service = Rc::new(RefCell::new(Service::from(platform)));
             let mut apps = self.create_apps(&mut service);
 
             log::info!("Ready for work");


### PR DESCRIPTION
To make this library more flexible, this PR introduces an `Apps` trait for structs that own a set of applications.  This also makes it possible to integrate the usbip runner with the actual firmware.