### PR TITLE
Add timeouts for keepalive messages

### DIFF
--- a/src/ccid.rs
+++ b/src/ccid.rs
@@ -1,7 +1,11 @@
+use std::time::{Duration, Instant};
+
 use apdu_dispatch::dispatch::ApduDispatch;
 use apdu_dispatch::interchanges::Data;
 use usb_device::bus::{UsbBus, UsbBusAllocator};
-use usbd_ccid::Ccid;
+use usbd_ccid::{Ccid, Status};
+
+use super::Timeout;
 
 pub fn setup<'bus, 'pipe, B: UsbBus>(
     bus_allocator: &'bus UsbBusAllocator<B>,
@@ -12,4 +16,21 @@ pub fn setup<'bus, 'pipe, B: UsbBus>(
     let ccid = Ccid::new(bus_allocator, ccid_rq, None);
     let apdu_dispatch = ApduDispatch::new(ccid_rp, contactless.split().unwrap().1);
     (ccid, apdu_dispatch)
+}
+
+pub fn keepalive<B: UsbBus, const N: usize>(
+    ccid: &mut Ccid<'_, '_, B, N>,
+    timeout: &mut Timeout,
+    epoch: Instant,
+) {
+    timeout.update(epoch, map_status(ccid.did_start_processing()), || {
+        map_status(ccid.send_wait_extension())
+    });
+}
+
+fn map_status(status: Status) -> Option<Duration> {
+    match status {
+        Status::ReceivedData(ms) => Some(Duration::from_millis(ms.0.into())),
+        Status::Idle => None,
+    }
 }

--- a/src/ctaphid.rs
+++ b/src/ctaphid.rs
@@ -1,6 +1,13 @@
+use std::{
+    sync::atomic::Ordering,
+    time::{Duration, Instant},
+};
+
 use ctaphid_dispatch::dispatch::Dispatch;
 use usb_device::bus::{UsbBus, UsbBusAllocator};
-use usbd_ctaphid::CtapHid;
+use usbd_ctaphid::{types::Status, CtapHid};
+
+use super::{Timeout, IS_WAITING};
 
 pub fn setup<'bus, 'pipe, 'interrupt, B: UsbBus>(
     bus_allocator: &'bus UsbBusAllocator<B>,
@@ -16,4 +23,21 @@ pub fn setup<'bus, 'pipe, 'interrupt, B: UsbBus>(
         .implements_wink();
     let ctaphid_dispatch = Dispatch::new(ctaphid_rp);
     (ctaphid, ctaphid_dispatch)
+}
+
+pub fn keepalive<B: UsbBus>(
+    ctaphid: &mut CtapHid<'_, '_, '_, B>,
+    timeout: &mut Timeout,
+    epoch: Instant,
+) {
+    timeout.update(epoch, map_status(ctaphid.did_start_processing()), || {
+        map_status(ctaphid.send_keepalive(IS_WAITING.load(Ordering::Relaxed)))
+    });
+}
+
+fn map_status(status: Status) -> Option<Duration> {
+    match status {
+        Status::ReceivedData(ms) => Some(Duration::from_millis(ms.0.into())),
+        Status::Idle => None,
+    }
 }


### PR DESCRIPTION
Our initial implementation of CTAPHID and CCID keepalive messages was a bit too simple by potentially sending keepalive messages every five milliseconds.  This could overwhelm clients and, most importantly, spams the log output.

This patch adds proper keepalive timeout handling, respecting the timeout returned by the USB classes (currently 250 ms for CTAPHID and 1 s for CCID).  This is also closer to the behavior on hardware.