### PR TITLE
Add missing metadata to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "trussed-usbip"
 version = "0.1.0-rc.1"
+description = "USBIP runner for trussed applications"
 authors = ["The Trussed developers", "Nicolas Stalder <n@stalder.io>", "Conor Patrick <conor@solokeys.com>", "Szczepan Zalega <szczepan@nitrokey.com>"]
+repository = "https://github.com/trussed-dev/pc-usbip-runner"
+license = "Apache-2.0 OR MIT"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
Unfortunately this was not caught by the CI because the missing metadata is rejected by the crates.io server, not by `cargo publish`.